### PR TITLE
Don't output notBefore field

### DIFF
--- a/check_ssl.sh
+++ b/check_ssl.sh
@@ -91,7 +91,7 @@ if [[ -z "${PROTOCOL}" ]]; then
 	done
 	DATE_EXPIRE_SECONDS=$(echo "${HOST_CHECK}" | sed 's/^notAfter=//g' | xargs -I{} date -d {} +%s)
 else
-		HOST_CHECK=$(openssl s_client -servername "${HOST}" -connect "${HOST}":"${PORT}" -starttls "${PROTOCOL}" 2>&- | openssl x509 -enddate -noout -dates)
+		HOST_CHECK=$(openssl s_client -servername "${HOST}" -connect "${HOST}":"${PORT}" -starttls "${PROTOCOL}" 2>&- | openssl x509 -enddate -noout)
 	while [ "${?}" = "1" ]; do
 		echo "Check Hostname"
 		exit 1


### PR DESCRIPTION
When checking the SSL certificate for an SMTP server for example, both the notBefore (`-startdate`) and notAfter (`-enddate`) fields are reported by openssl because the `-dates` option is used in addition to `-enddate`.

This causes `date` to report an invalid date, because the sed expression only expects the notAfter field:
```
date: invalid date ‘notBefore=Aug 19 13:33:33 2013 GMT’
OK: Cert will expire on: 2023-08-17
```