### PR TITLE
Added CommonName of certificate to plugin output

### DIFF
--- a/check_ssl.sh
+++ b/check_ssl.sh
@@ -98,7 +98,7 @@ if [[ -z "${PROTOCOL}" ]]; then
 		exit 2
 	done
 	DATE_EXPIRE_SECONDS=$(echo "${HOST_CHECK}" | grep "notAfter" |sed 's/^notAfter=//g' | xargs -I{} date -d {} +%s)
-        COMMON_NAME=$(echo "${HOST_CHECK}" | grep "subject" | sed 's/^.*CN=//' | sed 's/\s.*$//')
+      COMMON_NAME=$(echo "${HOST_CHECK}" | grep "subject" | sed 's/^.*CN=//' | sed 's/\s.*$//')
 else
 	HOST_CHECK=$(openssl s_client -servername "${HOST}" -connect "${IP}":"${PORT}" -starttls "${PROTOCOL}" 2>&- | openssl x509 -enddate -subject -noout)
 	while [ "${?}" = "1" ]; do

--- a/check_ssl.sh
+++ b/check_ssl.sh
@@ -98,7 +98,13 @@ if [[ -z "${PROTOCOL}" ]]; then
 		exit 2
 	done
 	DATE_EXPIRE_SECONDS=$(echo "${HOST_CHECK}" | grep "notAfter" |sed 's/^notAfter=//g' | xargs -I{} date -d {} +%s)
-      COMMON_NAME=$(echo "${HOST_CHECK}" | grep "subject" | sed 's/^.*CN=//' | sed 's/\s.*$//')
+	if [[ $(echo "${HOST_CHECK}" | grep "subject" | grep "CN=" > /dev/null; echo $?) -eq 0 ]]; then
+		# OpenSSL 1.0.X output format
+		COMMON_NAME=$(echo "${HOST_CHECK}" | grep "subject" | sed 's/^.*CN=//' | sed 's/\s.*$//')
+	elif [[ $(echo "${HOST_CHECK}" | grep "subject" | grep "CN = " > /dev/null; echo $?) -eq 0 ]]; then
+		# OpenSSL 1.1.X output format
+		COMMON_NAME=$(echo "${HOST_CHECK}" | grep "subject" | sed 's/^.*CN = //' | sed 's/\s.*$//')
+	fi
 else
 	HOST_CHECK=$(openssl s_client -servername "${HOST}" -connect "${IP}":"${PORT}" -starttls "${PROTOCOL}" 2>&- | openssl x509 -enddate -subject -noout)
 	while [ "${?}" = "1" ]; do
@@ -106,7 +112,13 @@ else
 		exit 2
 	done
 	DATE_EXPIRE_SECONDS=$(echo "${HOST_CHECK}" | grep "notAfter" | sed 's/^notAfter=//g' | xargs -I{} date -d {} +%s)
-        COMMON_NAME=$(echo "${HOST_CHECK}" | grep "subject" | sed 's/^.*CN=//' | sed 's/\s.*$//')
+	if [[ $(echo "${HOST_CHECK}" | grep "subject" | grep "CN=" > /dev/null; echo $?) -eq 0 ]]; then
+		# OpenSSL 1.0.X output format
+		COMMON_NAME=$(echo "${HOST_CHECK}" | grep "subject" | sed 's/^.*CN=//' | sed 's/\s.*$//')
+	elif [[ $(echo "${HOST_CHECK}" | grep "subject" | grep "CN = " > /dev/null; echo $?) -eq 0 ]]; then
+		# OpenSSL 1.1.X output format
+		COMMON_NAME=$(echo "${HOST_CHECK}" | grep "subject" | sed 's/^.*CN = //' | sed 's/\s.*$//')
+	fi
 fi
 
 #-------------------
@@ -120,15 +132,15 @@ DATE_DIFFERENCE_DAYS=$((${DATE_DIFFERENCE_SECONDS}/60/60/24))
 # OUTPUT |
 #---------
 if [[ "${DATE_DIFFERENCE_DAYS}" -le "${CRITICAL_DAYS}" && "${DATE_DIFFERENCE_DAYS}" -ge "0" ]]; then
-	echo -e "CRITICAL: Cert "$COMMON_NAME" will expire on: "${DATE_EXPIRE_FORMAT}""
+	echo -e "CRITICAL: Cert $COMMON_NAME will expire on: "${DATE_EXPIRE_FORMAT}""
 	exit 2
 elif [[ "${DATE_DIFFERENCE_DAYS}" -le "${WARNING_DAYS}" && "${DATE_DIFFERENCE_DAYS}" -ge "0" ]]; then
-	echo -e "WARNING: Cert "$COMMON_NAME" will expire on: "${DATE_EXPIRE_FORMAT}""
+	echo -e "WARNING: Cert $COMMON_NAME will expire on: "${DATE_EXPIRE_FORMAT}""
 	exit 1
 elif [[ "${DATE_DIFFERENCE_DAYS}" -lt "0" ]]; then
-	echo -e "CRITICAL: Cert "$COMMON_NAME" expired on: "${DATE_EXPIRE_FORMAT}""
+	echo -e "CRITICAL: Cert $COMMON_NAME expired on: "${DATE_EXPIRE_FORMAT}""
 	exit 2
 else
-	echo -e "OK: Cert "$COMMON_NAME" will expire on: "${DATE_EXPIRE_FORMAT}""
+	echo -e "OK: Cert $COMMON_NAME will expire on: "${DATE_EXPIRE_FORMAT}""
 	exit 0
 fi

--- a/check_ssl.sh
+++ b/check_ssl.sh
@@ -92,19 +92,21 @@ DATE_ACTUALLY_SECONDS=$(date +"%s")
 # GET CERTIFICATE |
 #------------------
 if [[ -z "${PROTOCOL}" ]]; then
-	HOST_CHECK=$(openssl s_client -servername "${HOST}" -connect "${IP}":"${PORT}" 2>&- | openssl x509 -enddate -noout)
+	HOST_CHECK=$(openssl s_client -servername "${HOST}" -connect "${IP}":"${PORT}" 2>&- | openssl x509 -enddate -subject -noout)
 	while [ "${?}" = "1" ]; do
 		echo "Check Hostname"
 		exit 2
 	done
-	DATE_EXPIRE_SECONDS=$(echo "${HOST_CHECK}" | sed 's/^notAfter=//g' | xargs -I{} date -d {} +%s)
+	DATE_EXPIRE_SECONDS=$(echo "${HOST_CHECK}" | grep "notAfter" |sed 's/^notAfter=//g' | xargs -I{} date -d {} +%s)
+        COMMON_NAME=$(echo "${HOST_CHECK}" | grep "subject" | sed 's/^.*CN=//' | sed 's/\s.*$//')
 else
-		HOST_CHECK=$(openssl s_client -servername "${HOST}" -connect "${IP}":"${PORT}" -starttls "${PROTOCOL}" 2>&- | openssl x509 -enddate -noout)
+	HOST_CHECK=$(openssl s_client -servername "${HOST}" -connect "${IP}":"${PORT}" -starttls "${PROTOCOL}" 2>&- | openssl x509 -enddate -subject -noout)
 	while [ "${?}" = "1" ]; do
 		echo "Check Hostname"
 		exit 2
 	done
-	DATE_EXPIRE_SECONDS=$(echo "${HOST_CHECK}" | sed 's/^notAfter=//g' | xargs -I{} date -d {} +%s)
+	DATE_EXPIRE_SECONDS=$(echo "${HOST_CHECK}" | grep "notAfter" | sed 's/^notAfter=//g' | xargs -I{} date -d {} +%s)
+        COMMON_NAME=$(echo "${HOST_CHECK}" | grep "subject" | sed 's/^.*CN=//' | sed 's/\s.*$//')
 fi
 
 #-------------------
@@ -118,15 +120,15 @@ DATE_DIFFERENCE_DAYS=$((${DATE_DIFFERENCE_SECONDS}/60/60/24))
 # OUTPUT |
 #---------
 if [[ "${DATE_DIFFERENCE_DAYS}" -le "${CRITICAL_DAYS}" && "${DATE_DIFFERENCE_DAYS}" -ge "0" ]]; then
-	echo -e "CRITICAL: Cert will expire on: "${DATE_EXPIRE_FORMAT}""
+	echo -e "CRITICAL: Cert "$COMMON_NAME" will expire on: "${DATE_EXPIRE_FORMAT}""
 	exit 2
 elif [[ "${DATE_DIFFERENCE_DAYS}" -le "${WARNING_DAYS}" && "${DATE_DIFFERENCE_DAYS}" -ge "0" ]]; then
-	echo -e "WARNING: Cert will expire on: "${DATE_EXPIRE_FORMAT}""
+	echo -e "WARNING: Cert "$COMMON_NAME" will expire on: "${DATE_EXPIRE_FORMAT}""
 	exit 1
 elif [[ "${DATE_DIFFERENCE_DAYS}" -lt "0" ]]; then
-	echo -e "CRITICAL: Cert expired on: "${DATE_EXPIRE_FORMAT}""
+	echo -e "CRITICAL: Cert "$COMMON_NAME" expired on: "${DATE_EXPIRE_FORMAT}""
 	exit 2
 else
-	echo -e "OK: Cert will expire on: "${DATE_EXPIRE_FORMAT}""
+	echo -e "OK: Cert "$COMMON_NAME" will expire on: "${DATE_EXPIRE_FORMAT}""
 	exit 0
 fi


### PR DESCRIPTION
I've added the CN of the retrieved certificate to the plugin output.

This is useful when monitoring certificates on web servers/load balancers with multiple vHosts to make sure you are actually monitoring the certificate of the correct vHost.

**Previous output**
`OK: Cert will expire on: 2023-04-27`
**New output**
`OK: Cert vhost.example.com will expire on: 2023-04-27`