### PR TITLE
Set default warning/critical values according to help text

### DIFF
--- a/check_ssl.sh
+++ b/check_ssl.sh
@@ -23,6 +23,13 @@ HELP () {
 	exit
 }
 
+#-----------------
+# DEFAULT VALUES |
+#-----------------
+CRITICAL_DAYS=5
+QUIET=0
+WARNING_DAYS=30
+
 #---------------
 # GET HOSTINFO |
 #---------------


### PR DESCRIPTION
The help text says default warning days value is 30, default critical days value is 5.
The actual code does not have any defaul values.
This patch sets them.